### PR TITLE
Modify AMD Autoupdater

### DIFF
--- a/.github/workflows/amd-updater-task.yml
+++ b/.github/workflows/amd-updater-task.yml
@@ -20,10 +20,12 @@ jobs:
       - name: install python packages
         run: |
           python -m pip install --upgrade pip
-      - name: Install xmllint
+      - name: Install curl
         run: sudo apt-get install -y curl
-          
-      - name: execute py script # run sj-gobierno.py to get the latest data
+      - name: Install curl
+        run: sudo apt-get install -y p7zip-full
+        
+      - name: execute py script # 
         env: 
           EMAIL_ADDRESS: ${{ secrets.EMAIL_ADDRESS }}
           EMAIL_PASSWORD: ${{ secrets.EMAIL_PASSWORD }}

--- a/.github/workflows/amd-updater-task.yml
+++ b/.github/workflows/amd-updater-task.yml
@@ -1,14 +1,9 @@
 name: amd-updater-task
 
-on: 
-  workflow_dispatch:
-    inputs:
-      logLevel:
-        description: 'Log level'     
-        required: true
-        default: 'warning'
-      tags:
-        description: 'Test scenario tags'  
+
+on:
+  schedule:
+    - cron: "*/120 * * * *"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/amd-updater-task.yml
+++ b/.github/workflows/amd-updater-task.yml
@@ -1,9 +1,14 @@
 name: amd-updater-task
 
-on:
-  schedule:
-    - cron: "*/120 * * * *"
-
+on: 
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'     
+        required: true
+        default: 'warning'
+      tags:
+        description: 'Test scenario tags'  
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/amd-updater.py
+++ b/.github/workflows/amd-updater.py
@@ -1,29 +1,30 @@
 import subprocess,json,time
+ 
+latest_driver_link = ""
 URL = r"""curl -f -A 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36' -L https://www.amd.com/en/support/graphics/amd-radeon-6000-series/amd-radeon-6900-series/amd-radeon-rx-6900-xt --referer 'https://www.amd.com/en' | grep -Eo 'https?://\S+?\"' """
 co = subprocess.check_output(URL, shell=True).decode('utf-8')
-dictionary_of_drivers = {}
 for link in co.splitlines():
     if ".exe" in link and "pro-software" not in link and "minimalsetup" not in link:
-        damnthisshit = (link.split('-'))
-        for comeon in damnthisshit:
-            if comeon.count('.') >= 2 and ".com" not in comeon:
-                dictionary_of_drivers[comeon] = link
-latest_driver_link = (dictionary_of_drivers[max(dictionary_of_drivers)])
-latest_driver_version = max(dictionary_of_drivers)
+        latest_driver_link = link[:link.find(".exe")+4]
+        break
 time.sleep(30)
-windows_driver_version = r"""curl -f -A 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36' -L https://www.amd.com/en/support/kb/release-notes/rn-rad-win-""" + latest_driver_version.replace('.','-') +  """ --referer 'https://www.amd.com/en'"""
-windows_driver_version_output = subprocess.check_output(windows_driver_version, shell=True).decode('utf-8')
+Driver_URL = r"curl -f -A 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36' -L " + latest_driver_link + " --referer 'https://www.amd.com/en' -o amddriver.exe" 
+ 
+co = subprocess.check_output(Driver_URL, shell=True)
+ 
+z_extract = "7z x amddriver.exe Config/InstallManifest.json" 
+ 
+co = subprocess.check_output(z_extract, shell=True)
+ 
+latest_driver_version = ""
 latest_driver_store_version = ""
-for possible_driver_version in windows_driver_version_output.splitlines():
-    if "Windows Driver Store" in possible_driver_version:
-        latest_driver_store_version = possible_driver_version[possible_driver_version.find("Windows Driver Store Version ")+29:possible_driver_version.find(")")]
+with open("Config/InstallManifest.json") as f:
+    data = json.load(f)
+    latest_driver_version = (data['BuildInfo']['ExternalVersion'])
+    latest_driver_store_version = ((data['Packages']['Package'][0]['Info']['version']))
  
  
-print(latest_driver_link)
-print(latest_driver_version)
-print(latest_driver_store_version)
-
-
+ 
 with open('amd_gpu.json', 'r+') as f:
     data = json.load(f)
     if latest_driver_version > data["consumer"]["version"]:

--- a/.github/workflows/amd-updater.py
+++ b/.github/workflows/amd-updater.py
@@ -1,4 +1,4 @@
-import subprocess,json,time
+import subprocess,json,time,hashlib,shutil,os
  
 latest_driver_link = ""
 URL = r"""curl -f -A 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/97.0.4692.99 Safari/537.36' -L https://www.amd.com/en/support/graphics/amd-radeon-6000-series/amd-radeon-6900-series/amd-radeon-rx-6900-xt --referer 'https://www.amd.com/en' | grep -Eo 'https?://\S+?\"' """
@@ -31,7 +31,12 @@ with open('amd_gpu.json', 'r+') as f:
         data["consumer"]["version"] = latest_driver_version
         data["consumer"]["win_driver_version"] = latest_driver_store_version
         data["consumer"]["link"] = latest_driver_link
+        print("Getting MD5")
+        data["consumer"]["MD5"] = hashlib.md5("amddriver.exe").hexdigest()
+        print("MD5 got and written")
     f.seek(0)
     json.dump(data, f, indent=4)
     f.truncate()     # remove remaining part
     print(data)
+shutil.rmtree('Config/InstallManifest.json')
+os.remove("amddriver.exe")

--- a/.github/workflows/amd-updater.py
+++ b/.github/workflows/amd-updater.py
@@ -32,7 +32,7 @@ with open('amd_gpu.json', 'r+') as f:
         data["consumer"]["win_driver_version"] = latest_driver_store_version
         data["consumer"]["link"] = latest_driver_link
         print("Getting MD5")
-        data["consumer"]["MD5"] = hashlib.md5("amddriver.exe").hexdigest()
+        data["consumer"]["MD5"] = hashlib.md5(open("amddriver.exe",'rb').read()).hexdigest()
         print("MD5 got and written")
     f.seek(0)
     json.dump(data, f, indent=4)

--- a/.github/workflows/amd-updater.py
+++ b/.github/workflows/amd-updater.py
@@ -38,5 +38,5 @@ with open('amd_gpu.json', 'r+') as f:
     json.dump(data, f, indent=4)
     f.truncate()     # remove remaining part
     print(data)
-shutil.rmtree('/Config/InstallManifest.json')
+shutil.rmtree('Config')
 os.remove("amddriver.exe")

--- a/.github/workflows/amd-updater.py
+++ b/.github/workflows/amd-updater.py
@@ -38,5 +38,5 @@ with open('amd_gpu.json', 'r+') as f:
     json.dump(data, f, indent=4)
     f.truncate()     # remove remaining part
     print(data)
-shutil.rmtree('Config/InstallManifest.json')
+shutil.rmtree('/Config/InstallManifest.json')
 os.remove("amddriver.exe")

--- a/amd_gpu.json
+++ b/amd_gpu.json
@@ -1,6 +1,6 @@
 {
     "consumer": {
-        "version": "22.1.2",
+        "version": "22.1.1",
         "win_driver_version": "30.0.14023.3004",
         "link": "https://drivers.amd.com/drivers/radeon-software-adrenalin-2020-22.1.2-win10-win11-64bit-jan25.exe",
         "MD5": "4A70EA8DDF93A52AA6C11E8EBD0F1FA6"

--- a/amd_gpu.json
+++ b/amd_gpu.json
@@ -1,8 +1,8 @@
 {
     "consumer": {
-        "version": "22.1.1",
+        "version": "22.1.2",
         "win_driver_version": "30.0.14023.3004",
         "link": "https://drivers.amd.com/drivers/radeon-software-adrenalin-2020-22.1.2-win10-win11-64bit-jan25.exe",
-        "MD5": "4A70EA8DDF93A52AA6C11E8EBD0F1FA6"
+        "MD5": "7107b606ed275dd60d6ebd153ff1a5af"
     }
 }


### PR DESCRIPTION
Instead of trying to fetch the information of the driver from AMD's website, it instead downloads the driver and looks into the InstallManifest and grabs the needed information from there. I believe this greatly reduces the chances of this breaking, as the only assumption we're making from AMD's website is that they list the newest driver first, which has been the case since at least 2018.
